### PR TITLE
Add position_on_page to panel loop

### DIFF
--- a/resources/views/default.antlers.html
+++ b/resources/views/default.antlers.html
@@ -1,3 +1,3 @@
 {{ panels }}
-	{{ partial src="_panels/{type}" }}
+    {{ partial src="_panels/{type}" position_on_page="{{ count }}" }}
 {{ /panels }}


### PR DESCRIPTION
This lets you determine if lazy loading should be in place (eg the first hero image at the top of a page should not be lazy loaded for page-speed scores)