### PR TITLE
Update JS and cache tracker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "private": true,
+    "type": "module",
     "scripts": {
         "dev": "vite",
         "build": "vite build --watch"
@@ -9,12 +10,14 @@
         "autoprefixer": "^10.4.14",
         "laravel-vite-plugin": "^0.7.2",
         "postcss": "^8.4.23",
-        "tailwindcss": "^3.3.2",
+        "tailwindcss": "^3.4.1",
         "vite": "^4.0.0"
     },
     "dependencies": {
-        "alpinejs": "^3.13.5",
-        "laravel-precognition-alpine": "^0.5.4",
-        "swiper": "^5.2.0"
+        "@alpinejs/intersect": "^3.14.1",
+        "@alpinejs/resize": "^3.14.1",
+        "alpinejs": "^3.14.1",
+        "laravel-precognition-alpine": "^0.5.6",
+        "swiffy-slider": "^1.6.0"
     }
 }

--- a/resources/js/site.js
+++ b/resources/js/site.js
@@ -1,10 +1,22 @@
-import Alpine from 'alpinejs'
+import { Livewire, Alpine } from '../../vendor/livewire/livewire/dist/livewire.esm';
+import intersect from '@alpinejs/intersect';
 import Precognition from 'laravel-precognition-alpine';
-import Swiper from 'swiper';
-import 'swiper/css/swiper.css';
+import { swiffyslider } from 'swiffy-slider';
+
+import "swiffy-slider/css";
 
 window.Alpine = Alpine;
-window.Swiper = Swiper;
+window.swiffyslider = swiffyslider;
 
 Alpine.plugin(Precognition);
-Alpine.start();
+Alpine.plugin(intersect);
+
+if (window.livewireScriptConfig?.csrf === 'STATAMIC_CSRF_TOKEN') {
+    document.addEventListener('statamic:nocache.replaced', () => Livewire.start());
+} else {
+    Livewire.start();
+}
+
+window.addEventListener('load', () => {
+    window.swiffyslider.init();
+});

--- a/starter-kit.yaml
+++ b/starter-kit.yaml
@@ -44,7 +44,7 @@ dependencies:
   spatie/geocoder: ^3.15
   statamic/seo-pro: '*'
   thoughtco/statamic-blurhash: ^1.0
-  thoughtco/statamic-cache-tracker: ^0.3
+  thoughtco/statamic-cache-tracker: ^0.8
   thoughtco/statamic-cookiepanel: ^2.0
   thoughtco/statamic-cp-resources: ^1.0
   thoughtco/statamic-minify: ^2.0


### PR DESCRIPTION
JS out of the box doesn't work as theres no `type: module`, this fixes this.

We also use swiffy now, not slider, so this brings it in.

I've taken the chance to refactor the JS to bring things up to date as a better starting point, eg we can assume we use Livewire on most projects so pull Alpine from there.

Also updates cache tracker to 0.8 as it keeps loading in 0.3 even though the composer dep should go higher.