### PR TITLE
We dont need scheduled cache invalidator any more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ config/.DS_Store
 content/.DS_Store
 content/collections/.DS_Store
 content/trees/.DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -37,12 +37,6 @@ By default the following packages are added:
 - Checks form submission content against Postmarks spam check API
 - Full documentation at https://packagist.org/packages/thoughtco/statamic-postmark-spamcheck
 
-
-**Scheduled Cache Invalidator**
-- A command to help invalidate the cache when scheduled Statamic entries are due to go live.
-- Full documentation at https://packagist.org/packages/mitydigital/statamic-scheduled-cache-invalidator
-
-
 **SEOPro:**
 - Allows the Search Engine Management of each entry and can be configured using the statamic/seo-pro.php config file
 - Allows the production of sitemap.xml

--- a/app/Listeners/EntryListener.php
+++ b/app/Listeners/EntryListener.php
@@ -53,6 +53,11 @@ class EntryListener
         //     }
         // }
     }
+
+    public function scheduleReached(Events\EntryScheduleReached $event)
+    {
+        $event->entry->save(); // we save the entry to kick the stache and run any invalidation
+    }
 }
 
 ?>

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -40,6 +40,10 @@ class EventServiceProvider extends ServiceProvider
             [Listeners\EntryListener::class, 'saved'],
         ],
 
+        Events\EntryScheduleReached::class => [
+            [Listeners\EntryListener::class, 'scheduleReached'],
+        ],
+
         Events\FormSubmitted::class => [
             Listeners\FormListener::class,
         ],

--- a/starter-kit.yaml
+++ b/starter-kit.yaml
@@ -24,7 +24,6 @@ export_paths:
   - config/thoughtco/client-dashboard.php
   - config/thoughtco/minify.php
   - config/thoughtco/site.php
-  - config/statamic-scheduled-cache-invalidator.php
   - resources/blueprints
   - resources/css/site.css
   - resources/fieldsets
@@ -40,7 +39,6 @@ dependencies:
   coconutcraig/laravel-postmark: ^3.2
   duncanmcclean/static-cache-manager: ^4.0
   jonassiewertsen/statamic-livewire: ^3.0
-  mitydigital/statamic-scheduled-cache-invalidator: ^2.0
   spatie/geocoder: ^3.15
   statamic/seo-pro: '*'
   thoughtco/statamic-cache-tracker: ^0.8


### PR DESCRIPTION
This PR removes the scheduled cache invalidator from the starter kit, in favour of using the EntryScheduleReached event which is now in core.

If we need more custom logic around entry invalidation on a site, e.g. end dates, then we should make our own console task similar to: https://github.com/statamic/cms/pull/10966/files#diff-8c932ba43769f8a546c1e542ddb75ce38daca224ca29d5b20f31610f89e8c499


