### PR TITLE
Panel screenshots script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Starter Kit
 The starter kit is an attempt give you the additional extras TC run on top of a Statamic install. If you feel something else which is used on a regular basis should be installed, let us know and we can have a look.
 
@@ -78,6 +79,16 @@ We don’t use our own servers to send emails from, we rely on Postmark for deli
 - Please try and get into the habit of this.
     - It allows you the ability to edit the panel once.
     - It allows the panel to be re-used in different areas of the website if necessary.
+
+#### Field previews
+Once all field sets have been added to the Pages blueprint it is possible to generate image previews of these fields automatically by running
+
+```
+node scripts/panel-screenshots.js
+```
+
+This should be done after all the fieldsets have been added.
+
 
 ### Fieldsets
 There are three fieldsets setup in the default build:

--- a/app/Http/Controllers/PanelScreenshotController.php
+++ b/app/Http/Controllers/PanelScreenshotController.php
@@ -9,7 +9,7 @@ class PanelScreenshotController extends Controller
 {
     public function show(string $handle)
     {
-        $fieldsetPath = resource_path("fieldsets/panel_{$handle}.yaml");
+        $fieldsetPath = resource_path("fieldsets/{$handle}.yaml");
 
         abort_if(! file_exists($fieldsetPath), 404, "No fieldset found for panel: {$handle}");
 

--- a/app/Http/Controllers/PanelScreenshotController.php
+++ b/app/Http/Controllers/PanelScreenshotController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Statamic\Facades\YAML;
+use Statamic\View\View;
+
+class PanelScreenshotController extends Controller
+{
+    public function show(string $handle)
+    {
+        $fieldsetPath = resource_path("fieldsets/panel_{$handle}.yaml");
+
+        abort_if(! file_exists($fieldsetPath), 404, "No fieldset found for panel: {$handle}");
+
+        $fieldset = YAML::parse(file_get_contents($fieldsetPath));
+        $dummy    = $this->buildDummyData($fieldset['fields'] ?? []);
+        $dummy['type'] = $handle;
+
+        return View::make('__panel-screenshot')
+            ->with(['_panel_handle' => $handle] + $dummy);
+    }
+
+    /**
+     * Recursively build dummy data from a fieldset's fields array.
+     * Handles all field types used across panel fieldsets, including
+     * nested fieldset imports (e.g. handle: link, field.import: button).
+     */
+    private function buildDummyData(array $fields): array
+    {
+        $data = [];
+
+        foreach ($fields as $field) {
+            // Top-level fieldset import — no handle, just `import: fieldset-name`
+            // Merges the imported fieldset's fields directly into the current scope.
+            if (isset($field['import']) && ! isset($field['handle'])) {
+                $importPath = resource_path("fieldsets/{$field['import']}.yaml");
+                if (file_exists($importPath)) {
+                    $imported = YAML::parse(file_get_contents($importPath));
+                    $data = array_merge($data, $this->buildDummyData($imported['fields'] ?? []));
+                }
+                continue;
+            }
+
+            $handle = $field['handle'] ?? null;
+            if (! $handle) continue;
+
+            $def  = $field['field'] ?? [];
+            $type = $def['type'] ?? null;
+
+            // Field-level import — handle: foo, field.import: fieldset-name
+            // Produces a nested array (e.g. link: { link_type: ..., url: ... }).
+            if (isset($def['import'])) {
+                $importPath = resource_path("fieldsets/{$def['import']}.yaml");
+                if (file_exists($importPath)) {
+                    $imported = YAML::parse(file_get_contents($importPath));
+                    $data[$handle] = $this->buildDummyData($imported['fields'] ?? []);
+                } else {
+                    $data[$handle] = [];
+                }
+                continue;
+            }
+
+            // UI-only field types — skip
+            if ($type === 'section') continue;
+
+            // Use the field's configured default value when available
+            if (array_key_exists('default', $def)) {
+                $data[$handle] = $def['default'];
+                continue;
+            }
+
+            $data[$handle] = match ($type) {
+                'text'         => 'Lorem ipsum dolor sit amet',
+                'textarea'     => "Lorem ipsum dolor sit amet\nconsectetur adipiscing elit",
+                'bard'         => '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>',
+                'button_group' => array_key_first($def['options'] ?? []),
+                'select'       => array_key_first($def['options'] ?? []),
+                'toggle'       => false,
+                'integer'      => 1,
+                'assets'       => null,
+                'video'        => null,
+                'entries'      => null,
+                'replicator'   => [],
+                default        => null,
+            };
+        }
+
+        return $data;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "vite build --watch"
+        "build": "vite build --watch",
+        "screenshots": "node scripts/panel-screenshots.js"
     },
     "devDependencies": {
+        "puppeteer": "^23.0.0",
         "@tailwindcss/typography": "^0.5.16",
         "@tailwindcss/vite": "^4.1.11",
         "alpinejs-textarea-grow": "^1.0.5",

--- a/resources/views/__panel-screenshot.antlers.html
+++ b/resources/views/__panel-screenshot.antlers.html
@@ -1,0 +1,3 @@
+<div id="screenshot-output">
+    {{ partial src="_panels/{_panel_handle}" }}
+</div>

--- a/resources/views/__panel-screenshot.antlers.html
+++ b/resources/views/__panel-screenshot.antlers.html
@@ -1,3 +1,20 @@
-<div id="screenshot-output">
-    {{ partial src="_panels/{_panel_handle}" }}
-</div>
+<!DOCTYPE html>
+<html prefix="og: http://ogp.me/ns#" lang="en">
+<head>
+
+    <base href="{{ site:url }}" />
+
+    <!-- css -->
+    <link rel="preload" as="style" href="{{ vite:asset src="resources/css/site.css" }}" />
+    <link href="{{ vite:asset src="resources/css/site.css" }}" rel="stylesheet" type="text/css" media="screen" />
+
+</head>
+<body x-data="{ showSubmenu : false, showMobileSubmenu : false }" :class="{ 'overflow-hidden' : showSubmenu }">
+
+    <div id="screenshot-output">
+        {{ partial src="_panels/{_panel_handle}" }}
+    </div>
+
+</body>
+
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\PanelScreenshotController;
 use Illuminate\Support\Facades\Route;
 use Statamic\View\View;
 
@@ -10,4 +11,10 @@ if (app()->environment() == 'staging'){
         return View::make("cutup.{$page}")
             ->layout('layout');
     });
+}
+
+// Panel screenshot route — renders a single panel in isolation using dummy data
+// generated from its fieldset. Only available outside production.
+if (! app()->environment('production')) {
+    Route::get('__panel-screenshot/{handle}', [PanelScreenshotController::class, 'show']);
 }

--- a/scripts/panel-screenshots.js
+++ b/scripts/panel-screenshots.js
@@ -2,18 +2,15 @@
  * Panel Screenshots Generator
  * Generates screenshot thumbnails for each Statamic replicator panel set.
  *
- * Everything is auto-discovered from the project filesystem — no explicit panel
- * list required:
+ * Everything is auto-discovered — no explicit panel list required:
  *
  *   1. Scans resources/views/_panels/*.antlers.html for panel handles.
- *   2. Reads each template to extract the CSS selector from the outer <section>.
- *   3. Scans content/collections/**\/*.md to find the first page that uses each panel.
- *   4. Determines the DOM index for panels that share a selector on the same page.
- *   5. Loads the source page in one browser tab, extracts just that panel's HTML.
- *   6. Renders an isolated dummy page (only that panel + compiled CSS/JS) in a
- *      second tab and screenshots the <section> element.
- *   7. Writes the preview path back into any blueprint YAML that references the
- *      panel set handle.
+ *   2. For each handle, visits /__panel-screenshot/{handle} — a dedicated route
+ *      that renders just that panel (with real CMS data) inside #screenshot-output.
+ *   3. Screenshots the #screenshot-output element.
+ *   4. Writes a Statamic .meta YAML file alongside each image.
+ *   5. Updates the image: path in any blueprint YAML that references the handle.
+ *   6. Runs `php please stache:clear` once all screenshots are done.
  *
  * Usage:
  *   node scripts/panel-screenshots.js [base-url] [handle]
@@ -31,6 +28,7 @@
  */
 
 import puppeteer from 'puppeteer';
+import { execSync } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
@@ -42,6 +40,17 @@ const ROOT       = path.join(__dirname, '..');
 const BASE_URL   = (process.argv[2] || readEnvUrl() || 'http://localhost:8000').replace(/\/$/, '');
 const ONLY       = process.argv[3] ?? null;
 
+const PANELS_DIR    = path.join(ROOT, 'resources', 'views', '_panels');
+const BLUEPRINT_DIR = path.join(ROOT, 'resources', 'blueprints');
+const OUTPUT_DIR    = path.join(ROOT, 'public', 'assets', 'files', 'panel-screenshots');
+const META_DIR      = path.join(OUTPUT_DIR, '.meta');
+
+const YAML_PREVIEW_BASE = 'panel-screenshots';
+
+// ---------------------------------------------------------------------------
+// .env reader
+// ---------------------------------------------------------------------------
+
 /** Read APP_URL from the project's .env file, stripping surrounding quotes. */
 function readEnvUrl() {
     const envFile = path.join(ROOT, '.env');
@@ -50,22 +59,11 @@ function readEnvUrl() {
     return match ? match[1].trim() : null;
 }
 
-const PANELS_DIR   = path.join(ROOT, 'resources', 'views', '_panels');
-const CONTENT_DIR  = path.join(ROOT, 'content', 'collections');
-const BLUEPRINT_DIR = path.join(ROOT, 'resources', 'blueprints');
-const OUTPUT_DIR   = path.join(ROOT, 'public', 'assets', 'files', 'panel-screenshots');
-
-// Relative path stored in blueprint YAML (relative to assets/files/)
-const YAML_PREVIEW_BASE = 'assets/files/panel-screenshots';
-
 // ---------------------------------------------------------------------------
-// Discovery helpers
+// Panel discovery
 // ---------------------------------------------------------------------------
 
-/**
- * Return all panel handles found in resources/views/_panels/.
- * Handle = filename without the .antlers.html extension.
- */
+/** Return all panel handles found in resources/views/_panels/. */
 function discoverHandles() {
     return fs.readdirSync(PANELS_DIR)
         .filter(f => f.endsWith('.antlers.html'))
@@ -73,78 +71,41 @@ function discoverHandles() {
         .sort();
 }
 
-/**
- * Read the panel's Antlers template and extract the first CSS class from the
- * outer <section> element, e.g. `<section class="blog-listing px-6 …">` → `.blog-listing`
- */
-function selectorFromTemplate(handle) {
-    const file = path.join(PANELS_DIR, `${handle}.antlers.html`);
-    const src  = fs.readFileSync(file, 'utf8');
-    const match = src.match(/<section[^>]+class="([^"]+)"/);
-    if (!match) return null;
-    const firstClass = match[1].trim().split(/\s+/)[0];
-    return `.${firstClass}`;
-}
-
-/**
- * Scan all .md content files under content/collections/ and return a map of
- * handle → { file, url, rawTypes }
- *
- * rawTypes is the ordered list of all panel `type:` values found in that file,
- * used later to compute the DOM index for duplicate selectors.
- */
-function discoverContentMap() {
-    const result = {}; // handle → { file, url, rawTypes }
-
-    const mdFiles = findFiles(CONTENT_DIR, f => f.endsWith('.md'));
-
-    for (const file of mdFiles) {
-        const src = fs.readFileSync(file, 'utf8');
-
-        // Collect all panel types in document order
-        const typeMatches = [...src.matchAll(/^\s+type:\s+(\S+)\s*$/gm)];
-        const rawTypes = typeMatches.map(m => m[1]);
-        if (rawTypes.length === 0) continue;
-
-        // Derive the URL from the `slug:` field in the front matter
-        const slugMatch = src.match(/^slug:\s*(.+)$/m);
-        let slug = slugMatch ? slugMatch[1].trim() : path.basename(file, '.md');
-        const url = slug.startsWith('/') ? BASE_URL + slug : `${BASE_URL}/${slug}`;
-
-        for (const handle of rawTypes) {
-            if (!result[handle]) {
-                result[handle] = { file, url, rawTypes };
-            }
-        }
-    }
-
-    return result;
-}
-
-/**
- * Given a handle, its selector, and the ordered list of panel types on the
- * chosen source page, compute which index (0-based) this handle occupies
- * among panels that share the same CSS selector.
- */
-function computeIndex(handle, selector, rawTypes) {
-    let idx = 0;
-    for (const type of rawTypes) {
-        if (type === handle) return idx;
-        if (selectorFromTemplate(type) === selector) idx++;
-    }
-    return 0; // fallback
-}
-
 // ---------------------------------------------------------------------------
-// YAML update helper
+// Statamic .meta file writer
 // ---------------------------------------------------------------------------
 
 /**
- * Search all blueprint YAML files for a block matching `{handle}:` that
- * contains a `display:` key (characteristic of a replicator set entry) and
- * add or replace its `preview:` line.
- *
- * Works by line-by-line analysis so it preserves all other formatting/comments.
+ * Write a Statamic asset .meta YAML file for a saved image.
+ * Path convention: {asset_dir}/.meta/{filename}.yaml
+ */
+function writeMetaFile(imagePath, width, height) {
+    const stat     = fs.statSync(imagePath);
+    const filename = path.basename(imagePath);
+
+    fs.mkdirSync(META_DIR, { recursive: true });
+
+    const meta = [
+        `data: []`,
+        `size: ${stat.size}`,
+        `last_modified: ${Math.floor(stat.mtimeMs / 1000)}`,
+        `width: ${Math.round(width)}`,
+        `height: ${Math.round(height)}`,
+        `mime_type: image/jpeg`,
+        `duration: null`,
+    ].join('\n') + '\n';
+
+    fs.writeFileSync(path.join(META_DIR, `${filename}.yaml`), meta, 'utf8');
+}
+
+// ---------------------------------------------------------------------------
+// Blueprint YAML updater
+// ---------------------------------------------------------------------------
+
+/**
+ * Search all blueprint YAML files for a replicator set block matching `handle`
+ * and add or replace its `image:` line.
+ * Works line-by-line to preserve all existing formatting and comments.
  */
 function updateBlueprintPreview(handle, previewPath) {
     const yamlFiles = findFiles(BLUEPRINT_DIR, f => f.endsWith('.yaml') || f.endsWith('.yml'));
@@ -152,10 +113,9 @@ function updateBlueprintPreview(handle, previewPath) {
 
     for (const file of yamlFiles) {
         const original = fs.readFileSync(file, 'utf8');
-        const result   = patchYamlPreview(original, handle, previewPath);
-
-        if (result !== original) {
-            fs.writeFileSync(file, result, 'utf8');
+        const patched  = patchYamlPreview(original, handle, previewPath);
+        if (patched !== original) {
+            fs.writeFileSync(file, patched, 'utf8');
             updated++;
         }
     }
@@ -163,54 +123,43 @@ function updateBlueprintPreview(handle, previewPath) {
     return updated;
 }
 
-/**
- * Patch a YAML string in-place:
- *  - Finds the line `{indent}{handle}:\n`
- *  - Verifies it's a replicator set block (contains `display:`)
- *  - Replaces or inserts `preview: {previewPath}` within that block
- */
 function patchYamlPreview(src, handle, previewPath) {
-    const lines  = src.split('\n');
-    const out    = [];
+    const lines = src.split('\n');
+    const out   = [];
     let i = 0;
 
     while (i < lines.length) {
-        const line = lines[i];
-        // Match a YAML key that is exactly the handle, possibly with leading spaces
+        const line     = lines[i];
         const keyMatch = line.match(/^(\s+)([\w]+):\s*$/);
 
         if (keyMatch && keyMatch[2] === handle) {
             const baseIndent = keyMatch[1];
             const propIndent = baseIndent + '  ';
 
-            // Collect this block (all lines indented deeper than baseIndent)
-            const blockStart = i;
             i++;
             const blockLines = [];
 
             while (i < lines.length) {
                 const bl = lines[i];
-                // A blank line or a line that is not more-indented ends the block
                 if (bl.trim() === '' || (bl.trim() !== '' && !bl.startsWith(baseIndent + ' '))) break;
                 blockLines.push(bl);
                 i++;
             }
 
-            // Only patch blocks that look like replicator set entries
+            // Only patch blocks that look like replicator set entries (have a display: key)
             const hasDisplay = blockLines.some(l => l.trim().startsWith('display:'));
             if (!hasDisplay) {
                 out.push(line, ...blockLines);
                 continue;
             }
 
-            const previewLine   = `${propIndent}preview: ${previewPath}`;
-            const existingIdx   = blockLines.findIndex(l => /^\s+preview:/.test(l));
-            const fieldsIdx     = blockLines.findIndex(l => l.trim().startsWith('fields:'));
+            const previewLine  = `${propIndent}image: ${previewPath}`;
+            const existingIdx  = blockLines.findIndex(l => /^\s+image:/.test(l));
+            const fieldsIdx    = blockLines.findIndex(l => l.trim().startsWith('fields:'));
 
             if (existingIdx >= 0) {
                 blockLines[existingIdx] = previewLine;
             } else {
-                // Insert before `fields:`, or at the end of the block
                 const insertAt = fieldsIdx >= 0 ? fieldsIdx : blockLines.length;
                 blockLines.splice(insertAt, 0, previewLine);
             }
@@ -223,60 +172,6 @@ function patchYamlPreview(src, handle, previewPath) {
     }
 
     return out.join('\n');
-}
-
-// ---------------------------------------------------------------------------
-// Isolated page builder
-// ---------------------------------------------------------------------------
-
-/**
- * Build a minimal standalone HTML page containing only the panel markup.
- * Root-relative URLs are converted to absolute so images/fonts resolve when
- * the page is rendered outside the site's URL context.
- */
-function buildIsolatedPage(panelHTML, assets, baseUrl) {
-    const html = absolutifyUrls(panelHTML, baseUrl);
-
-    const styleLinks = assets.css
-        .map(href => `<link rel="stylesheet" href="${href}">`)
-        .join('\n');
-
-    const scriptTags = assets.js
-        .map(src => `<script type="module" src="${src}"></script>`)
-        .join('\n');
-
-    return `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width">
-${styleLinks}
-<style>
-  *, *::before, *::after { box-sizing: border-box; }
-  body { margin: 0; padding: 0; }
-  [x-cloak] { display: none !important; }
-</style>
-</head>
-<body>
-${html}
-${scriptTags}
-</body>
-</html>`;
-}
-
-/**
- * Convert root-relative URLs in HTML attribute values to absolute.
- * Handles src, href, action, and srcset attributes.
- */
-function absolutifyUrls(html, baseUrl) {
-    const base = baseUrl.replace(/\/$/, '');
-    return html
-        .replace(/\b(src|href|action)="(\/[^"]*)"/g,  `$1="${base}$2"`)
-        .replace(/\b(src|href|action)='(\/[^']*)'/g,  `$1='${base}$2'`)
-        .replace(/\bsrcset="([^"]*)"/g, (_, s) =>
-            `srcset="${s.replace(/((?:^|,\s*))(\/[^\s,]+)/g, `$1${base}$2`)}"`)
-        .replace(/\bsrcset='([^']*)'/g, (_, s) =>
-            `srcset='${s.replace(/((?:^|,\s*))(\/[^\s,]+)/g, `$1${base}$2`)}'`);
 }
 
 // ---------------------------------------------------------------------------
@@ -303,9 +198,8 @@ function delay(ms) {
 // ---------------------------------------------------------------------------
 
 async function run() {
-    // 1. Discover all panel handles from the _panels directory
     const allHandles = discoverHandles();
-    const handles = ONLY ? allHandles.filter(h => h === ONLY) : allHandles;
+    const handles    = ONLY ? allHandles.filter(h => h === ONLY) : allHandles;
 
     if (ONLY && handles.length === 0) {
         console.error(`Unknown panel handle: "${ONLY}"`);
@@ -313,50 +207,10 @@ async function run() {
         process.exit(1);
     }
 
-    // 2. Build selector map from templates
-    const selectors = {};
-    for (const handle of handles) {
-        selectors[handle] = selectorFromTemplate(handle);
-    }
-
-    // 3. Find which page URL contains each panel
-    const contentMap = discoverContentMap();
-
-    // 4. Assemble the full panel config
-    const panels = [];
-    const skipped = [];
-
-    for (const handle of handles) {
-        const selector = selectors[handle];
-        if (!selector) {
-            skipped.push(`${handle} (no <section> found in template)`);
-            continue;
-        }
-
-        const content = contentMap[handle];
-        if (!content) {
-            skipped.push(`${handle} (not used on any content page)`);
-            continue;
-        }
-
-        const index = computeIndex(handle, selector, content.rawTypes);
-        panels.push({ handle, url: content.url, selector, index });
-    }
-
-    if (skipped.length) {
-        console.warn(`Skipping ${skipped.length} panel(s):`);
-        skipped.forEach(s => console.warn(`  ✗ ${s}`));
-        console.warn('');
-    }
-
-    if (panels.length === 0) {
-        console.error('No panels to screenshot.');
-        process.exit(1);
-    }
-
     fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+    fs.mkdirSync(META_DIR, { recursive: true });
 
-    console.log(`Panel Screenshots — ${panels.length} panel${panels.length !== 1 ? 's' : ''}`);
+    console.log(`Panel Screenshots — ${handles.length} panel${handles.length !== 1 ? 's' : ''}`);
     console.log(`Base URL : ${BASE_URL}`);
     console.log(`Output   : ${OUTPUT_DIR}\n`);
 
@@ -365,92 +219,63 @@ async function run() {
         args: ['--no-sandbox', '--disable-setuid-sandbox'],
     });
 
-    // Two tabs:
-    //   sourcePage  — loads the live site once per unique URL to get server-rendered HTML
-    //   previewPage — renders the isolated dummy page and takes the screenshot
-    const sourcePage  = await browser.newPage();
-    const previewPage = await browser.newPage();
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1440, height: 900 });
 
-    await sourcePage.setViewport({ width: 1440, height: 900 });
-    await previewPage.setViewport({ width: 1440, height: 900 });
-    previewPage.on('console', () => {}); // suppress noise
+    let succeeded = 0;
 
-    // Group panels by source URL so we only load each page once
-    const byUrl = new Map();
-    for (const panel of panels) {
-        if (!byUrl.has(panel.url)) byUrl.set(panel.url, []);
-        byUrl.get(panel.url).push(panel);
-    }
+    for (const handle of handles) {
+        const url        = `${BASE_URL}/__panel-screenshot/${handle}`;
+        const outputPath = path.join(OUTPUT_DIR, `${handle}.jpg`);
 
-    // Vite bundles the same CSS/JS on every page — cache after the first load
-    let assets = null;
-
-    for (const [url, group] of byUrl) {
-        console.log(`  Loading ${url}`);
+        process.stdout.write(`  [${handle}] `);
 
         try {
-            await sourcePage.goto(url, { waitUntil: 'networkidle2', timeout: 30000 });
-        } catch (err) {
-            console.warn(`  ✗ Could not load ${url}: ${err.message}`);
-            group.forEach(p => console.log(`    SKIP [${p.handle}]`));
-            continue;
-        }
+            const response = await page.goto(url, { waitUntil: 'networkidle2', timeout: 30000 });
 
-        // Let lazy content / Alpine.js finish its initial render
-        await delay(800);
-
-        // Grab all compiled CSS and JS URLs from the page <head> once
-        if (!assets) {
-            assets = await sourcePage.evaluate(() => ({
-                css: [...document.querySelectorAll('link[rel="stylesheet"]')].map(l => l.href),
-                js:  [...document.querySelectorAll('script[type="module"][src]')].map(s => s.src),
-            }));
-        }
-
-        for (const { handle, selector, index } of group) {
-            process.stdout.write(`  [${handle}] `);
-
-            try {
-                // Extract the server-rendered HTML for this panel only
-                const panelHTML = await sourcePage.evaluate((sel, idx) => {
-                    const el = document.querySelectorAll(sel)[idx];
-                    return el ? el.outerHTML : null;
-                }, selector, index);
-
-                if (!panelHTML) {
-                    const count = await sourcePage.$$eval(selector, els => els.length);
-                    console.log(`SKIP — "${selector}" not found (${count} match${count !== 1 ? 'es' : ''} on page, wanted index ${index})`);
-                    continue;
-                }
-
-                // Build and render a minimal page containing only this panel
-                const isolated = buildIsolatedPage(panelHTML, assets, BASE_URL);
-                await previewPage.setContent(isolated, { waitUntil: 'networkidle2', timeout: 30000 });
-                await delay(500);
-
-                // Screenshot just the <section> element — the only panel in the page
-                const el = await previewPage.$('section');
-                if (!el) {
-                    console.log('SKIP — no <section> found in isolated page');
-                    continue;
-                }
-
-                const outputPath = path.join(OUTPUT_DIR, `${handle}.jpg`);
-                await el.screenshot({ path: outputPath, type: 'jpeg', quality: 85 });
-
-                // Write the preview path back into any blueprint YAML that references this handle
-                const previewYamlPath = `${YAML_PREVIEW_BASE}/${handle}.jpg`;
-                const patchedFiles = updateBlueprintPreview(handle, previewYamlPath);
-
-                console.log(`✓  ${handle}.jpg${patchedFiles ? ` (YAML updated)` : ''}`);
-
-            } catch (err) {
-                console.log(`✗  ${err.message}`);
+            if (response.status() === 404) {
+                console.log(`SKIP — 404 (panel not used on any page)`);
+                continue;
             }
+
+            // Allow Alpine.js / lazy images to finish rendering
+            await delay(600);
+
+            const el = await page.$('#screenshot-output');
+            if (!el) {
+                console.log(`SKIP — #screenshot-output not found in response`);
+                continue;
+            }
+
+            await el.screenshot({ path: outputPath, type: 'jpeg', quality: 85 });
+
+            // Dimensions from the rendered element's bounding box
+            const box = await el.boundingBox();
+            writeMetaFile(outputPath, box.width, box.height);
+
+            // Update blueprint YAML preview: path
+            const previewPath  = `${YAML_PREVIEW_BASE}/${handle}.jpg`;
+            const patchedFiles = updateBlueprintPreview(handle, previewPath);
+
+            console.log(`✓  ${handle}.jpg (${Math.round(box.width)}×${Math.round(box.height)})${patchedFiles ? ' · YAML updated' : ''}`);
+            succeeded++;
+
+        } catch (err) {
+            console.log(`✗  ${err.message}`);
         }
     }
 
     await browser.close();
+
+    if (succeeded > 0) {
+        console.log('\nClearing Statamic stache…');
+        try {
+            execSync('php please stache:clear', { cwd: ROOT, stdio: 'inherit' });
+        } catch {
+            console.warn('  stache:clear failed — run it manually if needed.');
+        }
+    }
+
     console.log('\nDone!');
 }
 

--- a/scripts/panel-screenshots.js
+++ b/scripts/panel-screenshots.js
@@ -1,0 +1,460 @@
+/**
+ * Panel Screenshots Generator
+ * Generates screenshot thumbnails for each Statamic replicator panel set.
+ *
+ * Everything is auto-discovered from the project filesystem — no explicit panel
+ * list required:
+ *
+ *   1. Scans resources/views/_panels/*.antlers.html for panel handles.
+ *   2. Reads each template to extract the CSS selector from the outer <section>.
+ *   3. Scans content/collections/**\/*.md to find the first page that uses each panel.
+ *   4. Determines the DOM index for panels that share a selector on the same page.
+ *   5. Loads the source page in one browser tab, extracts just that panel's HTML.
+ *   6. Renders an isolated dummy page (only that panel + compiled CSS/JS) in a
+ *      second tab and screenshots the <section> element.
+ *   7. Writes the preview path back into any blueprint YAML that references the
+ *      panel set handle.
+ *
+ * Usage:
+ *   node scripts/panel-screenshots.js [base-url] [handle]
+ *
+ *   base-url  optional  defaults to APP_URL from .env, then http://localhost:8000
+ *   handle    optional  re-run a single panel instead of all
+ *
+ * Examples:
+ *   node scripts/panel-screenshots.js
+ *   node scripts/panel-screenshots.js https://agconnect.test
+ *   node scripts/panel-screenshots.js https://agconnect.test page_hero
+ *
+ * Output saved to : public/assets/files/panel-screenshots/{handle}.jpg
+ * YAML preview    : assets/files/panel-screenshots/{handle}.jpg
+ */
+
+import puppeteer from 'puppeteer';
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const ROOT       = path.join(__dirname, '..');
+
+const BASE_URL   = (process.argv[2] || readEnvUrl() || 'http://localhost:8000').replace(/\/$/, '');
+const ONLY       = process.argv[3] ?? null;
+
+/** Read APP_URL from the project's .env file, stripping surrounding quotes. */
+function readEnvUrl() {
+    const envFile = path.join(ROOT, '.env');
+    if (!fs.existsSync(envFile)) return null;
+    const match = fs.readFileSync(envFile, 'utf8').match(/^APP_URL=["']?([^"'\r\n]+)["']?/m);
+    return match ? match[1].trim() : null;
+}
+
+const PANELS_DIR   = path.join(ROOT, 'resources', 'views', '_panels');
+const CONTENT_DIR  = path.join(ROOT, 'content', 'collections');
+const BLUEPRINT_DIR = path.join(ROOT, 'resources', 'blueprints');
+const OUTPUT_DIR   = path.join(ROOT, 'public', 'assets', 'files', 'panel-screenshots');
+
+// Relative path stored in blueprint YAML (relative to assets/files/)
+const YAML_PREVIEW_BASE = 'assets/files/panel-screenshots';
+
+// ---------------------------------------------------------------------------
+// Discovery helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return all panel handles found in resources/views/_panels/.
+ * Handle = filename without the .antlers.html extension.
+ */
+function discoverHandles() {
+    return fs.readdirSync(PANELS_DIR)
+        .filter(f => f.endsWith('.antlers.html'))
+        .map(f => f.replace(/\.antlers\.html$/, ''))
+        .sort();
+}
+
+/**
+ * Read the panel's Antlers template and extract the first CSS class from the
+ * outer <section> element, e.g. `<section class="blog-listing px-6 …">` → `.blog-listing`
+ */
+function selectorFromTemplate(handle) {
+    const file = path.join(PANELS_DIR, `${handle}.antlers.html`);
+    const src  = fs.readFileSync(file, 'utf8');
+    const match = src.match(/<section[^>]+class="([^"]+)"/);
+    if (!match) return null;
+    const firstClass = match[1].trim().split(/\s+/)[0];
+    return `.${firstClass}`;
+}
+
+/**
+ * Scan all .md content files under content/collections/ and return a map of
+ * handle → { file, url, rawTypes }
+ *
+ * rawTypes is the ordered list of all panel `type:` values found in that file,
+ * used later to compute the DOM index for duplicate selectors.
+ */
+function discoverContentMap() {
+    const result = {}; // handle → { file, url, rawTypes }
+
+    const mdFiles = findFiles(CONTENT_DIR, f => f.endsWith('.md'));
+
+    for (const file of mdFiles) {
+        const src = fs.readFileSync(file, 'utf8');
+
+        // Collect all panel types in document order
+        const typeMatches = [...src.matchAll(/^\s+type:\s+(\S+)\s*$/gm)];
+        const rawTypes = typeMatches.map(m => m[1]);
+        if (rawTypes.length === 0) continue;
+
+        // Derive the URL from the `slug:` field in the front matter
+        const slugMatch = src.match(/^slug:\s*(.+)$/m);
+        let slug = slugMatch ? slugMatch[1].trim() : path.basename(file, '.md');
+        const url = slug.startsWith('/') ? BASE_URL + slug : `${BASE_URL}/${slug}`;
+
+        for (const handle of rawTypes) {
+            if (!result[handle]) {
+                result[handle] = { file, url, rawTypes };
+            }
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Given a handle, its selector, and the ordered list of panel types on the
+ * chosen source page, compute which index (0-based) this handle occupies
+ * among panels that share the same CSS selector.
+ */
+function computeIndex(handle, selector, rawTypes) {
+    let idx = 0;
+    for (const type of rawTypes) {
+        if (type === handle) return idx;
+        if (selectorFromTemplate(type) === selector) idx++;
+    }
+    return 0; // fallback
+}
+
+// ---------------------------------------------------------------------------
+// YAML update helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Search all blueprint YAML files for a block matching `{handle}:` that
+ * contains a `display:` key (characteristic of a replicator set entry) and
+ * add or replace its `preview:` line.
+ *
+ * Works by line-by-line analysis so it preserves all other formatting/comments.
+ */
+function updateBlueprintPreview(handle, previewPath) {
+    const yamlFiles = findFiles(BLUEPRINT_DIR, f => f.endsWith('.yaml') || f.endsWith('.yml'));
+    let updated = 0;
+
+    for (const file of yamlFiles) {
+        const original = fs.readFileSync(file, 'utf8');
+        const result   = patchYamlPreview(original, handle, previewPath);
+
+        if (result !== original) {
+            fs.writeFileSync(file, result, 'utf8');
+            updated++;
+        }
+    }
+
+    return updated;
+}
+
+/**
+ * Patch a YAML string in-place:
+ *  - Finds the line `{indent}{handle}:\n`
+ *  - Verifies it's a replicator set block (contains `display:`)
+ *  - Replaces or inserts `preview: {previewPath}` within that block
+ */
+function patchYamlPreview(src, handle, previewPath) {
+    const lines  = src.split('\n');
+    const out    = [];
+    let i = 0;
+
+    while (i < lines.length) {
+        const line = lines[i];
+        // Match a YAML key that is exactly the handle, possibly with leading spaces
+        const keyMatch = line.match(/^(\s+)([\w]+):\s*$/);
+
+        if (keyMatch && keyMatch[2] === handle) {
+            const baseIndent = keyMatch[1];
+            const propIndent = baseIndent + '  ';
+
+            // Collect this block (all lines indented deeper than baseIndent)
+            const blockStart = i;
+            i++;
+            const blockLines = [];
+
+            while (i < lines.length) {
+                const bl = lines[i];
+                // A blank line or a line that is not more-indented ends the block
+                if (bl.trim() === '' || (bl.trim() !== '' && !bl.startsWith(baseIndent + ' '))) break;
+                blockLines.push(bl);
+                i++;
+            }
+
+            // Only patch blocks that look like replicator set entries
+            const hasDisplay = blockLines.some(l => l.trim().startsWith('display:'));
+            if (!hasDisplay) {
+                out.push(line, ...blockLines);
+                continue;
+            }
+
+            const previewLine   = `${propIndent}preview: ${previewPath}`;
+            const existingIdx   = blockLines.findIndex(l => /^\s+preview:/.test(l));
+            const fieldsIdx     = blockLines.findIndex(l => l.trim().startsWith('fields:'));
+
+            if (existingIdx >= 0) {
+                blockLines[existingIdx] = previewLine;
+            } else {
+                // Insert before `fields:`, or at the end of the block
+                const insertAt = fieldsIdx >= 0 ? fieldsIdx : blockLines.length;
+                blockLines.splice(insertAt, 0, previewLine);
+            }
+
+            out.push(line, ...blockLines);
+        } else {
+            out.push(line);
+            i++;
+        }
+    }
+
+    return out.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Isolated page builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal standalone HTML page containing only the panel markup.
+ * Root-relative URLs are converted to absolute so images/fonts resolve when
+ * the page is rendered outside the site's URL context.
+ */
+function buildIsolatedPage(panelHTML, assets, baseUrl) {
+    const html = absolutifyUrls(panelHTML, baseUrl);
+
+    const styleLinks = assets.css
+        .map(href => `<link rel="stylesheet" href="${href}">`)
+        .join('\n');
+
+    const scriptTags = assets.js
+        .map(src => `<script type="module" src="${src}"></script>`)
+        .join('\n');
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width">
+${styleLinks}
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+  body { margin: 0; padding: 0; }
+  [x-cloak] { display: none !important; }
+</style>
+</head>
+<body>
+${html}
+${scriptTags}
+</body>
+</html>`;
+}
+
+/**
+ * Convert root-relative URLs in HTML attribute values to absolute.
+ * Handles src, href, action, and srcset attributes.
+ */
+function absolutifyUrls(html, baseUrl) {
+    const base = baseUrl.replace(/\/$/, '');
+    return html
+        .replace(/\b(src|href|action)="(\/[^"]*)"/g,  `$1="${base}$2"`)
+        .replace(/\b(src|href|action)='(\/[^']*)'/g,  `$1='${base}$2'`)
+        .replace(/\bsrcset="([^"]*)"/g, (_, s) =>
+            `srcset="${s.replace(/((?:^|,\s*))(\/[^\s,]+)/g, `$1${base}$2`)}"`)
+        .replace(/\bsrcset='([^']*)'/g, (_, s) =>
+            `srcset='${s.replace(/((?:^|,\s*))(\/[^\s,]+)/g, `$1${base}$2`)}'`);
+}
+
+// ---------------------------------------------------------------------------
+// File system utility
+// ---------------------------------------------------------------------------
+
+function findFiles(dir, predicate) {
+    const results = [];
+    if (!fs.existsSync(dir)) return results;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) results.push(...findFiles(full, predicate));
+        else if (predicate(entry.name)) results.push(full);
+    }
+    return results;
+}
+
+function delay(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function run() {
+    // 1. Discover all panel handles from the _panels directory
+    const allHandles = discoverHandles();
+    const handles = ONLY ? allHandles.filter(h => h === ONLY) : allHandles;
+
+    if (ONLY && handles.length === 0) {
+        console.error(`Unknown panel handle: "${ONLY}"`);
+        console.error(`Discovered handles:\n  ${allHandles.join('\n  ')}`);
+        process.exit(1);
+    }
+
+    // 2. Build selector map from templates
+    const selectors = {};
+    for (const handle of handles) {
+        selectors[handle] = selectorFromTemplate(handle);
+    }
+
+    // 3. Find which page URL contains each panel
+    const contentMap = discoverContentMap();
+
+    // 4. Assemble the full panel config
+    const panels = [];
+    const skipped = [];
+
+    for (const handle of handles) {
+        const selector = selectors[handle];
+        if (!selector) {
+            skipped.push(`${handle} (no <section> found in template)`);
+            continue;
+        }
+
+        const content = contentMap[handle];
+        if (!content) {
+            skipped.push(`${handle} (not used on any content page)`);
+            continue;
+        }
+
+        const index = computeIndex(handle, selector, content.rawTypes);
+        panels.push({ handle, url: content.url, selector, index });
+    }
+
+    if (skipped.length) {
+        console.warn(`Skipping ${skipped.length} panel(s):`);
+        skipped.forEach(s => console.warn(`  ✗ ${s}`));
+        console.warn('');
+    }
+
+    if (panels.length === 0) {
+        console.error('No panels to screenshot.');
+        process.exit(1);
+    }
+
+    fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+
+    console.log(`Panel Screenshots — ${panels.length} panel${panels.length !== 1 ? 's' : ''}`);
+    console.log(`Base URL : ${BASE_URL}`);
+    console.log(`Output   : ${OUTPUT_DIR}\n`);
+
+    const browser = await puppeteer.launch({
+        headless: true,
+        args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+
+    // Two tabs:
+    //   sourcePage  — loads the live site once per unique URL to get server-rendered HTML
+    //   previewPage — renders the isolated dummy page and takes the screenshot
+    const sourcePage  = await browser.newPage();
+    const previewPage = await browser.newPage();
+
+    await sourcePage.setViewport({ width: 1440, height: 900 });
+    await previewPage.setViewport({ width: 1440, height: 900 });
+    previewPage.on('console', () => {}); // suppress noise
+
+    // Group panels by source URL so we only load each page once
+    const byUrl = new Map();
+    for (const panel of panels) {
+        if (!byUrl.has(panel.url)) byUrl.set(panel.url, []);
+        byUrl.get(panel.url).push(panel);
+    }
+
+    // Vite bundles the same CSS/JS on every page — cache after the first load
+    let assets = null;
+
+    for (const [url, group] of byUrl) {
+        console.log(`  Loading ${url}`);
+
+        try {
+            await sourcePage.goto(url, { waitUntil: 'networkidle2', timeout: 30000 });
+        } catch (err) {
+            console.warn(`  ✗ Could not load ${url}: ${err.message}`);
+            group.forEach(p => console.log(`    SKIP [${p.handle}]`));
+            continue;
+        }
+
+        // Let lazy content / Alpine.js finish its initial render
+        await delay(800);
+
+        // Grab all compiled CSS and JS URLs from the page <head> once
+        if (!assets) {
+            assets = await sourcePage.evaluate(() => ({
+                css: [...document.querySelectorAll('link[rel="stylesheet"]')].map(l => l.href),
+                js:  [...document.querySelectorAll('script[type="module"][src]')].map(s => s.src),
+            }));
+        }
+
+        for (const { handle, selector, index } of group) {
+            process.stdout.write(`  [${handle}] `);
+
+            try {
+                // Extract the server-rendered HTML for this panel only
+                const panelHTML = await sourcePage.evaluate((sel, idx) => {
+                    const el = document.querySelectorAll(sel)[idx];
+                    return el ? el.outerHTML : null;
+                }, selector, index);
+
+                if (!panelHTML) {
+                    const count = await sourcePage.$$eval(selector, els => els.length);
+                    console.log(`SKIP — "${selector}" not found (${count} match${count !== 1 ? 'es' : ''} on page, wanted index ${index})`);
+                    continue;
+                }
+
+                // Build and render a minimal page containing only this panel
+                const isolated = buildIsolatedPage(panelHTML, assets, BASE_URL);
+                await previewPage.setContent(isolated, { waitUntil: 'networkidle2', timeout: 30000 });
+                await delay(500);
+
+                // Screenshot just the <section> element — the only panel in the page
+                const el = await previewPage.$('section');
+                if (!el) {
+                    console.log('SKIP — no <section> found in isolated page');
+                    continue;
+                }
+
+                const outputPath = path.join(OUTPUT_DIR, `${handle}.jpg`);
+                await el.screenshot({ path: outputPath, type: 'jpeg', quality: 85 });
+
+                // Write the preview path back into any blueprint YAML that references this handle
+                const previewYamlPath = `${YAML_PREVIEW_BASE}/${handle}.jpg`;
+                const patchedFiles = updateBlueprintPreview(handle, previewYamlPath);
+
+                console.log(`✓  ${handle}.jpg${patchedFiles ? ` (YAML updated)` : ''}`);
+
+            } catch (err) {
+                console.log(`✗  ${err.message}`);
+            }
+        }
+    }
+
+    await browser.close();
+    console.log('\nDone!');
+}
+
+run().catch(err => {
+    console.error(err);
+    process.exit(1);
+});

--- a/scripts/panel-screenshots.js
+++ b/scripts/panel-screenshots.js
@@ -42,10 +42,8 @@ const ONLY       = process.argv[3] ?? null;
 
 const PANELS_DIR    = path.join(ROOT, 'resources', 'views', '_panels');
 const BLUEPRINT_DIR = path.join(ROOT, 'resources', 'blueprints');
-const OUTPUT_DIR    = path.join(ROOT, 'public', 'assets', 'files', 'panel-screenshots');
+const OUTPUT_DIR    = path.join(ROOT, 'public', 'assets', 'files', 'set-previews');
 const META_DIR      = path.join(OUTPUT_DIR, '.meta');
-
-const YAML_PREVIEW_BASE = 'panel-screenshots';
 
 // ---------------------------------------------------------------------------
 // .env reader
@@ -254,7 +252,7 @@ async function run() {
             writeMetaFile(outputPath, box.width, box.height);
 
             // Update blueprint YAML preview: path
-            const previewPath  = `${YAML_PREVIEW_BASE}/${handle}.jpg`;
+            const previewPath  = `${handle}.jpg`;
             const patchedFiles = updateBlueprintPreview(handle, previewPath);
 
             console.log(`✓  ${handle}.jpg (${Math.round(box.width)}×${Math.round(box.height)})${patchedFiles ? ' · YAML updated' : ''}`);

--- a/scripts/panel-screenshots.js
+++ b/scripts/panel-screenshots.js
@@ -272,6 +272,12 @@ async function run() {
         } catch {
             console.warn('  stache:clear failed — run it manually if needed.');
         }
+        console.log('\nClearing asset cache…');
+        try {
+            execSync('php please assets:clear-cache', { cwd: ROOT, stdio: 'inherit' });
+        } catch {
+            console.warn('  asset:clear-cache failed — run it manually if needed.');
+        }
     }
 
     console.log('\nDone!');

--- a/starter-kit.yaml
+++ b/starter-kit.yaml
@@ -6,6 +6,7 @@ export_paths:
   - content
   - app/Caching
   - app/Console
+  - app/Http/Controllers/PanelScreenshotController.php
   - app/Listeners
   - app/Providers/AppServiceProvider.php
   - app/Providers/EventServiceProvider.php

--- a/starter-kit.yaml
+++ b/starter-kit.yaml
@@ -36,6 +36,7 @@ export_paths:
   - resources/users
   - resources/views
   - routes/web.php
+  - scripts/panel-screenshots.js
   - users
 dependencies:
   aerni/social-links: ^3.3


### PR DESCRIPTION
This PR adds a panel screenshots script which you can run to assign screenshots for each panel in your replicator.

Usage:
```bash
node scripts/panel-screenshots.js
node scripts/panel-screenshots.js page_hero
```

@anditopping can you test this out locally and make sure it works as expected before merging?