### PR TITLE
Change order of muted attribute & update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ If you don't need any classes, simply leave the attribute out. Any classes shoul
 
 - **Video:** A series of fields that will allow the output of a 3rd party or local video using the code below. This should be used for all video output.
 
+    Any videos **MUST** be compressed with MP4 (Encoded as H.264) and Webm types created.
+
 ```
   {{ partial:_partials/snippets/video video_type="{video_type}" }}
 ```

--- a/resources/views/_partials/snippets/video.antlers.html
+++ b/resources/views/_partials/snippets/video.antlers.html
@@ -36,11 +36,11 @@
         <video
             class="lazy"
             preload="none"
-            playsinline
-            {{ if autoplay }}autoplay {{ /if }}
             {{ if mute }}muted {{ /if }}
+            {{ if autoplay }}autoplay {{ /if }}
             {{ if loop }}loop {{ /if }}
             {{ if show_controls }}controls {{ /if }}
+            playsinline
             width="100%"
             {{ if poster_image }}
                 poster="{{ glide:poster_image width='960' height='540' dpr='2' format='webp' }}"


### PR DESCRIPTION
Safari seems to prefer the muted attribute to be first. Any MP4 videos should also be H.264 encoded to be Safari safe.